### PR TITLE
Updated coord. computation to ensure rounding to 2 decimal places.

### DIFF
--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -236,6 +236,8 @@ class BlitzortungCoordinator:
             * math.cos(self.latitude * math.pi / 180)
         )
         distance = round(math.sqrt(dx * dx + dy * dy) * 6371, 1)
+        # Ensure clean rounding by converting to float with proper precision
+        distance = float(f"{distance:.1f}")
         azimuth = round(math.atan2(dx, dy) * 180 / math.pi) % 360
 
         lightning[ATTR_LIGHTNING_DISTANCE] = distance


### PR DESCRIPTION
Users were reporting that when converted to miles, the precision would be up-to 14 decimal places so I've added a conversion to float with 2 decimal places to hopefully catch any floating-point precision artifacts.

https://www.reddit.com/r/homeassistant/comments/1mav5qj/comment/n6i4kpv/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button